### PR TITLE
Fix double scroll bar in Windows 10

### DIFF
--- a/src/components/Carousel.svelte
+++ b/src/components/Carousel.svelte
@@ -2,7 +2,7 @@
   export let items = [];
 </script>
 
-<div class="slider relative w-full overflow-scroll bg-light">
+<div class="slider relative w-full overflow-x-scroll bg-light">
   <div class="slide-track flex">
     {#each items as item (item.node.id)}
       <a

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -109,7 +109,7 @@
     />
   {/if}
   <Header on:openCart={openCart} />
-  <div class="min-h-screen overflow-scroll">
+  <div class="min-h-screen">
     <slot />
     <Footer />
   </div>


### PR DESCRIPTION
Double scroll bar (`overflow: scroll`)
![Screenshot_20220913-162228_chrome](https://user-images.githubusercontent.com/47051820/189838888-13d93f90-c0d6-4ba3-a4ef-8b8638669c11.png)

Single scroll bar
![Screenshot_20220913-162232_chrome](https://user-images.githubusercontent.com/47051820/189838899-88e62c7e-0aca-4790-8499-a35cd00cd688.png)